### PR TITLE
add blob type and fix truthy null comparison

### DIFF
--- a/pgsqlite/pgsqlite.py
+++ b/pgsqlite/pgsqlite.py
@@ -28,6 +28,8 @@ class PGSqlite(object):
             return column_type.replace("NVARCHAR", "VARCHAR")
         elif "DATETIME" in column_type:
             return "TIMESTAMP"
+        elif "BLOB" in column_type:
+            return "BYTEA"
         return column_type
 
     def boolean_transformer(self, val: Any, nullable: bool) -> Union[bool, None]:
@@ -247,9 +249,8 @@ class PGSqlite(object):
                                     row[idx] = self.transformers[c.type](row[idx], not c.notnull)
                             if nullable_column_indexes:
                                 for idx in nullable_column_indexes:
-                                    if not row[idx]:
+                                    if row[idx] is None:
                                         row[idx] = None
-
                             copy.write_row(row)
                             rows_copied += 1
                             if rows_copied % 1000 == 0:


### PR DESCRIPTION
**Summary**

Adds minimal BLOB support, just use BYTEA as a starting point. 

Unrelatedly, Fixes a bug where a "truthy" Python comparison replaced integer value 0 with NULL. The same issue could occur with empty string, although in that case it's less obvious if the expected behavior should be empty string or NULL (with this change, it will be the former). This was observed when a non-null constraint broke data loading for an integer primary key column that contained "0".

**Testing**

Tested manually e2e with previously problematic db file. Not ideal, but no other testing for regressions at this early stage. 