### PR TITLE
Update Identifier Handling

### DIFF
--- a/pgsqlite/pgsqlite.py
+++ b/pgsqlite/pgsqlite.py
@@ -54,7 +54,7 @@ class ParsedTable(object):
     @property
     def columns(self):
         if self._columns is None:
-            # TODO: Handle case where ColumnDef has no type, causing sqlglot to
+            # Note for later PR: Handle case where ColumnDef has no type, causing sqlglot to
             # come up one column short. We want to impute a TEXT data type in
             # that case.
             parsed_cols = list(self.parsed_table.find_all(sqlglot.exp.ColumnDef))
@@ -67,7 +67,7 @@ class ParsedTable(object):
         return self._columns
 
     def get_transpiled_colname(self, source_colname: str) -> str:
-        # TODO: this lookup could be optimized with a dict
+        # Note for later PR: this lookup could be optimized with a dict
         for col in self.columns:
             if col.source_name == source_colname:
                 return col.transpiled_name
@@ -152,14 +152,14 @@ class PGSqlite(object):
         return self._tables
 
     def get_transpiled_tablename(self, source_tablename: str) -> str:
-        # TODO: this lookup could be optimized with a dict
+        # Note for later PR: this lookup could be optimized with a dict
         for table in self.tables:
             if table.source_name == source_tablename:
                 return table.transpiled_name
         raise ValueError("Requested transpiled name for unrecognized source table")
 
     def get_transpiled_colname(self, source_tablename: str, source_colname: str) -> str:
-        # TODO: this lookup could be optimized with a dict
+        # Note for later PR:  this lookup could be optimized with a dict
         for table in self.tables:
             if table.source_name == source_tablename:
                 return table.get_transpiled_colname(source_colname)
@@ -313,7 +313,7 @@ class PGSqlite(object):
         return tables_in_postgres
 
     def check_for_matching_tables(self) -> bool:
-        # TODO: implement me
+        # Note for later PR: implement me
         db = Database(self.sqlite_filename)
         tables_in_postgres = self.get_all_tables_in_postgres()
         return False

--- a/pgsqlite/pgsqlite.py
+++ b/pgsqlite/pgsqlite.py
@@ -24,6 +24,11 @@ SQLITE_SYSTEM_TABLES = ["sqlite_sequence", "sqlite_stat1", "sqlite_user"]
 logger = structlog.get_logger(__name__)
 
 
+class SchemaError(Exception):
+    """Raise for schema conditions that are invalid for pgsqlite"""
+    pass
+
+
 # We currently use both sqlite_utils and sqglot to extract and transpile database
 # schemas. ParsedTable (ParsedColumn) wraps both representations of each table
 # (column) object so that equivalent objects remain synced.
@@ -545,8 +550,3 @@ if __name__ == "__main__":
 
     if args.drop_tables_after_import:
         loader._drop_tables()
-
-
-class SchemaError(Exception):
-    """Raise for schema conditions that are invalid for pgsqlite"""
-    pass

--- a/pgsqlite/pgsqlite.py
+++ b/pgsqlite/pgsqlite.py
@@ -38,9 +38,9 @@ class ParsedTable(object):
     def __init__(self, table: sqlite_utils.db.Table):
         self._table = table
         self.parsed_table = sqlglot.parse_one(table.schema, read="sqlite")
-        # The first identifier in a parsed CREATE statement is the table name
-        self._tsp_table_name = (self.parsed_table.find(sqlglot.expressions.Identifier)
-                                                  .sql(dialect="postgres"))
+        self._tsp_table_name = (self.parsed_table.find(sqlglot.exp.Table)
+                                                 .find(sqlglot.exp.Identifier)
+                                                 .sql(dialect="postgres"))
         self._columns = None
     
     @property

--- a/pgsqlite/pgsqlite.py
+++ b/pgsqlite/pgsqlite.py
@@ -38,9 +38,15 @@ class ParsedTable(object):
     def __init__(self, table: sqlite_utils.db.Table):
         self.src_table = table
         self.parsed_table = sqlglot.parse_one(table.schema, read="sqlite")
-        self._tsp_table_name = (self.parsed_table.find(sqlglot.exp.Table)
-                                                 .find(sqlglot.exp.Identifier)
-                                                 .sql(dialect="postgres"))
+        # When we compose SQL w/ psycopg2.sql, values wrapped in Identifier are
+        # automatically quoted in Postgres. Therefore, we need to inspect for
+        # sqlite quotes and lower when quotes are not present to avoid mapping
+        # identifiers like `FOO` -> `"FOO"` as opposed to the expected `foo`
+        table_identifier = (self.parsed_table.find(sqlglot.exp.Table)
+                                             .find(sqlglot.exp.Identifier))
+        self._tsp_table_name = table_identifier.this
+        if not table_identifier.quoted:
+            self._tsp_table_name = self._tsp_table_name.lower()                      
         self._columns = None
     
     @property
@@ -87,8 +93,14 @@ class ParsedColumn(object):
         if (fk := parsed_column.find(sqlglot.exp.Reference)):
             fk.pop()
         self.parsed_column = parsed_column
-        self._tsp_column_name = (self.parsed_column.find(sqlglot.expressions.Identifier)
-                                                   .sql(dialect="postgres"))
+        # When we compose SQL w/ psycopg2.sql, values wrapped in Identifier are
+        # automatically quoted in Postgres. Therefore, we need to inspect for
+        # sqlite quotes and lower when quotes are not present to avoid mapping
+        # identifiers like `FOO` -> `"FOO"` as opposed to the expected `foo`
+        column_identifier = self.parsed_column.find(sqlglot.expressions.Identifier)
+        self._tsp_column_name = column_identifier.this
+        if not column_identifier.quoted:
+            self._tsp_column_name = self._tsp_column_name.lower()   
     
     @property
     def source_name(self):
@@ -167,7 +179,7 @@ class PGSqlite(object):
         # This is a little interesting. We can't use sqlglot.transpile directly, since we need to
         # avoid creating the foreign keys until we've loaded the data, and we don't support views/etc. 
         # So we assemble the rest of the table DDL by hand.
-        create_sql = SQL("CREATE TABLE {table_name} (").format(table_name=SQL(table.transpiled_name))
+        create_sql = SQL("CREATE TABLE {table_name} (").format(table_name=Identifier(table.transpiled_name))
         columns_sql = []
         cols = {}
         already_created_pks = [] 
@@ -202,7 +214,7 @@ class PGSqlite(object):
             all_column_sql = all_column_sql + SQL(",\n")
             pk_name = f"PK_{table.source_name}_" + ''.join(pks_to_add)
             pk_sql = SQL("    CONSTRAINT {pk_name} PRIMARY KEY ({pks})").format(
-                    table_name=SQL(table.transpiled_name),
+                    table_name=Identifier(table.transpiled_name),
                     pk_name=Identifier(pk_name), pks=SQL(", ").join(
                         [Identifier(t) for t in transpiled_pks_to_add]
                     ),
@@ -234,11 +246,11 @@ class PGSqlite(object):
         for fk in table.src_table.foreign_keys:
             fk_name = f"FK_{fk.other_table}_{fk.other_column}"
             fk_sql = SQL("ALTER TABLE {table_name} ADD CONSTRAINT {key_name}  FOREIGN KEY ({column}) REFERENCES {other_table} ({other_column})").format(
-                table_name=SQL(table.transpiled_name),
-                column=SQL(table.get_transpiled_colname(fk.column)),
+                table_name=Identifier(table.transpiled_name),
+                column=Identifier(table.get_transpiled_colname(fk.column)),
                 key_name=Identifier(fk_name),
-                other_table=SQL(self.get_transpiled_tablename(fk.other_table)),
-                other_column=SQL(self.get_transpiled_colname(fk.other_table, fk.other_column)),
+                other_table=Identifier(self.get_transpiled_tablename(fk.other_table)),
+                other_column=Identifier(self.get_transpiled_colname(fk.other_table, fk.other_column)),
             )
             sql.append(fk_sql)
         self.summary["tables"]["fks"][table.source_name] = {
@@ -258,13 +270,13 @@ class PGSqlite(object):
                 if col.desc:
                     order="DESC"
                 col_sql.append(SQL("{name} {sort_order}").format(
-                    name=SQL(table.get_transpiled_colname(col.name)),
+                    name=Identifier(table.get_transpiled_colname(col.name)),
                     sort_order=SQL(order)),
                 )
 
             index_sql = SQL("CREATE INDEX {index_name} ON {table_name} ({columns})").format(
                 index_name = Identifier(index.name),
-                table_name=SQL(table.transpiled_name),
+                table_name=Identifier(table.transpiled_name),
                 columns=SQL(",").join(col_sql)
             )
             sql.append(index_sql)
@@ -279,7 +291,7 @@ class PGSqlite(object):
             with conn.cursor() as cur:
                 for table in self.tables:
                     cur.execute(
-                        SQL("DROP TABLE IF EXISTS {table_name} CASCADE;").format(table_name=SQL(table.transpiled_name))
+                        SQL("DROP TABLE IF EXISTS {table_name} CASCADE;").format(table_name=Identifier(table.transpiled_name))
                     )
 
     def get_all_tables_in_postgres(self) -> Optional[List[Any]]:
@@ -368,7 +380,7 @@ class PGSqlite(object):
         # For any non-null column, allow convert from empty string to None
         async with await psycopg.AsyncConnection.connect(conninfo=self.pg_conninfo) as conn:
             async with conn.cursor() as pg_cur:
-                async with pg_cur.copy(f'COPY {table.transpiled_name} FROM STDIN') as copy:
+                async with pg_cur.copy(f'COPY "{table.transpiled_name}" FROM STDIN') as copy:
                     rows_copied = 0
                     for row in sl_cur:
                         row = list(row)

--- a/pgsqlite/pgsqlite.py
+++ b/pgsqlite/pgsqlite.py
@@ -541,10 +541,10 @@ if __name__ == "__main__":
     loader = PGSqlite(sqlite_filename, pg_conninfo, show_sample_data=args.show_sample_data, max_import_concurrency=args.max_import_concurrency)
     loader.load_schema(drop_existing_postgres_tables=args.drop_tables)
     loader.populate_postgres()
-    # logger.debug(json.dumps(loader.get_summary(), indent=2))
+    logger.debug(json.dumps(loader.get_summary(), indent=2))
 
-    # if args.drop_tables_after_import:
-    #     loader._drop_tables()
+    if args.drop_tables_after_import:
+        loader._drop_tables()
 
 
 class SchemaError(Exception):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "pgsqlite"
-VERSION = "1.0.1"
+VERSION = "1.0.2"
 # To install the library, run the following
 #
 # python setup.py install

--- a/test_schemas/identifier_variations.sql
+++ b/test_schemas/identifier_variations.sql
@@ -43,6 +43,14 @@ CREATE TABLE `PARENT_E` (
     `BAZ` TEXT
 );
 
+-- non-ascii, quoted
+CREATE TABLE "parent_f@/" (
+    "id@/" INTEGER PRIMARY KEY,
+    foo TEXT,
+    bar TEXT,
+    baz TEXT
+);
+
 -- child table referencing all parent tables
 CREATE TABLE child (
     child_id INTEGER PRIMARY KEY,
@@ -51,7 +59,8 @@ CREATE TABLE child (
     b_id INTEGER REFERENCES PARENT_B (ID),
     c_id INTEGER REFERENCES "PARENT_C" ("ID"),
     d_id INTEGER REFERENCES [PARENT_D] ([ID]),
-    e_id INTEGER REFERENCES `PARENT_E` (`ID`)
+    e_id INTEGER REFERENCES `PARENT_E` (`ID`),
+    f_id INTEGER REFERENCES "parent_f@/" ("id@/")
 );
 
 -- also test single and multi-column indexes with all variations
@@ -69,6 +78,9 @@ CREATE INDEX parent_d_multi_col ON [PARENT_D] ([BAR], [BAZ]);
 
 CREATE INDEX parent_e_single_col ON `PARENT_E` (`FOO`);
 CREATE INDEX parent_e_multi_col ON `PARENT_E` (`BAR`, `BAZ`);
+
+CREATE INDEX parent_f_single_col ON "parent_f@/" ("id@/");
+CREATE INDEX parent_f_multi_col ON "parent_f@/" ("id@/", foo);
 
 /* 
 In addition to double-quotes, brackets, and backticks, sqlite also "unofficially"
@@ -100,6 +112,10 @@ INSERT INTO `PARENT_E` VALUES
   (1, "apple", "orange", "banana"),
   (2, "orange", "apple", "banana");
 
+INSERT INTO "parent_f@/" VALUES
+  (1, "apple", "orange", "banana"),
+  (2, "orange", "apple", "banana");
+
 INSERT INTO child VALUES
-  (1, 'a', 1, 1, 1, 1, 1),
-  (2, 'b', 2, 2, 2, 2, 2);
+  (1, 'a', 1, 1, 1, 1, 1, 1),
+  (2, 'b', 2, 2, 2, 2, 2, 2);

--- a/test_schemas/identifier_variations.sql
+++ b/test_schemas/identifier_variations.sql
@@ -1,0 +1,105 @@
+/*
+This schema is intended to exercise all variations of sqlite quoting across
+table and column identifiers including within foreign keys and indexes.
+*/
+
+-- lowercase identifiers, no quoting
+CREATE TABLE parent_a (
+    id INTEGER PRIMARY KEY,
+    foo TEXT,
+    bar TEXT,
+    baz TEXT
+);
+
+-- uppercase identifiers, no quoting
+CREATE TABLE PARENT_B (
+    ID INTEGER PRIMARY KEY,
+    FOO TEXT,
+    BAR TEXT,
+    BAZ TEXT
+);
+
+-- uppercase identifiers, double-quoting
+CREATE TABLE "PARENT_C" (
+    "ID" INTEGER PRIMARY KEY,
+    "FOO" TEXT,
+    "BAR" TEXT,
+    "BAZ" TEXT
+);
+
+-- uppercase identifiers, bracket-quoting
+CREATE TABLE [PARENT_D] (
+    [ID] INTEGER PRIMARY KEY,
+    [FOO] TEXT,
+    [BAR] TEXT,
+    [BAZ] TEXT
+);
+
+-- uppercase identifiers, backtick-quoting
+CREATE TABLE `PARENT_E` (
+    `ID` INTEGER PRIMARY KEY,
+    `FOO` TEXT,
+    `BAR` TEXT,
+    `BAZ` TEXT
+);
+
+-- child table referencing all parent tables
+CREATE TABLE child (
+    child_id INTEGER PRIMARY KEY,
+    child_unique TEXT UNIQUE, -- test our ability to handle unique constraints
+    a_id INTEGER REFERENCES parent_a (id),
+    b_id INTEGER REFERENCES PARENT_B (ID),
+    c_id INTEGER REFERENCES "PARENT_C" ("ID"),
+    d_id INTEGER REFERENCES [PARENT_D] ([ID]),
+    e_id INTEGER REFERENCES `PARENT_E` (`ID`)
+);
+
+-- also test single and multi-column indexes with all variations
+CREATE INDEX parent_a_single_col ON parent_a (foo);
+CREATE INDEX parent_a_multi_col ON parent_a (bar, baz);
+
+CREATE INDEX parent_b_single_col ON PARENT_B (FOO);
+CREATE INDEX parent_b_multi_col ON PARENT_B (BAR, BAZ);
+
+CREATE INDEX parent_c_single_col ON "PARENT_C" ("FOO");
+CREATE INDEX parent_c_multi_col ON "PARENT_C" ("BAR", "BAZ");
+
+CREATE INDEX parent_d_single_col ON [PARENT_D] ([FOO]);
+CREATE INDEX parent_d_multi_col ON [PARENT_D] ([BAR], [BAZ]);
+
+CREATE INDEX parent_e_single_col ON `PARENT_E` (`FOO`);
+CREATE INDEX parent_e_multi_col ON `PARENT_E` (`BAR`, `BAZ`);
+
+/* 
+In addition to double-quotes, brackets, and backticks, sqlite also "unofficially"
+accepts single-quotes quoting of identifiers when the context disambiguates from
+a string literal. However, the sqlite maintainers note that this feature should
+not be relied upon and could change without notice. Replicating that tolerance
+in the sqlite dialect of the sqlglot parser doesn't seem worth it. For now,
+pgsqlite will not attempt to handle that condition beyond potentially adding
+informative errors when detected.
+*/
+
+INSERT INTO parent_a VALUES
+  (1, "apple", "orange", "banana"),
+  (2, "orange", "apple", "banana");
+
+INSERT INTO PARENT_B VALUES
+  (1, "apple", "orange", "banana"),
+  (2, "orange", "apple", "banana");
+
+INSERT INTO "PARENT_C" VALUES
+  (1, "apple", "orange", "banana"),
+  (2, "orange", "apple", "banana");
+
+INSERT INTO [PARENT_D] VALUES
+  (1, "apple", "orange", "banana"),
+  (2, "orange", "apple", "banana");
+
+INSERT INTO `PARENT_E` VALUES
+  (1, "apple", "orange", "banana"),
+  (2, "orange", "apple", "banana");
+
+INSERT INTO child VALUES
+  (1, 'a', 1, 1, 1, 1, 1),
+  (2, 'b', 2, 2, 2, 2, 2);

--- a/test_schemas/typeless_columns.sql
+++ b/test_schemas/typeless_columns.sql
@@ -1,0 +1,52 @@
+/*
+sqlite accepts "typeless" columns and stores the associated data as text.
+Therefore, we should import the following tables to Postgres w/ typeless
+columns as Postgres TEXT columns.
+*/
+
+CREATE TABLE table_a (
+    foo,
+    -- Testing an interleaving comment
+    bar INTEGER,
+    boo INTEGER
+);
+
+CREATE TABLE table_b (
+    foo INTEGER,
+    bar,
+    boo INTEGER
+);
+
+CREATE TABLE table_c (
+    foo INTEGER,
+    bar INTEGER,
+    boo
+);
+
+CREATE TABLE table_d (
+    foo INTEGER,
+    bar,
+    boo INTEGER,
+    baz
+);
+
+INSERT INTO table_a VALUES
+  (1, 2, 3),
+  ('hello', 2, 3),
+  (1, 2, 3);
+
+INSERT INTO table_b VALUES
+  (1, 2, 3),
+  (1, 'hello', 3),
+  (1, 2, 3);
+
+INSERT INTO table_c VALUES
+  (1, 2, 3),
+  (1, 2, 'hello'),
+  (1, 2, 3);
+
+INSERT INTO table_d VALUES
+  (1, 2, 3, 4),
+  (1, 'hello', 3, 'world'),
+  (1, 2, 3, 4),
+  (1, 'hello', 3, 'world');


### PR DESCRIPTION
Summary:

`sqlglot` has progressed significantly over the last few months, and we are now able to move more aspects of Postgres SQL generation (such as identifier mapping) into `sqlglot`. However, we still depend on schema data from `sqlite_utils` in many locations within `pgsqlite`. This change:

1. Adds thin wrapper classes around the table and column objects from `sqlite_utils` and `sqlglot` so that we can keep equivalent entities synced while generating the target schema and loading data. In particular, these wrappers handle mapping from source to target identifier names, which fixes a couple limitations of `pgslite` where un-quoted identifiers with caps break in the presence of foreign keys and indexes. This also enables us to maintain analogous quoting semantics into Postgres rather than treating all identifiers as quoted.
2. Removes a limitation where foreign key constraints embedded in column defs could break data loads (as we intent to only create foreign keys after loading). 
3. Adds more system tables that need to be ignored, as they do not have valid Postgres representations and break the schema creation process. 

Note: also working on a stacked PR to fast-follow with handling of typeless sqlite columns.

Testing:

Successfully processes sqlite database created using `identifier_variations.sql` with equivalent quoted/unquoted identifiers, foreign keys, and indexes validated in target database using `psql`.
