### PR TITLE
Handle typeless columns

### DIFF
--- a/pgsqlite/pgsqlite.py
+++ b/pgsqlite/pgsqlite.py
@@ -465,7 +465,6 @@ class PGSqlite(object):
         with psycopg.connect(conninfo=self.pg_conninfo) as conn:
             with conn.cursor() as cur:
                 for create_sql in self.tables_sql:
-                    breakpoint()
                     logger.debug("Running SQL:")
                     logger.debug(create_sql.as_string(conn))
                     cur.execute(create_sql)

--- a/test_schemas/typeless_columns.sql
+++ b/test_schemas/typeless_columns.sql
@@ -1,5 +1,12 @@
+/*
+sqlite accepts "typeless" columns and stores the associated data as text.
+Therefore, we should import the following tables to Postgres w/ typeless
+columns as Postgres TEXT columns.
+*/
+
 CREATE TABLE table_a (
     foo,
+    -- Testing an interleaving comment
     bar INTEGER,
     boo INTEGER
 );
@@ -16,17 +23,30 @@ CREATE TABLE table_c (
     boo
 );
 
+CREATE TABLE table_d (
+    foo INTEGER,
+    bar,
+    boo INTEGER,
+    baz
+);
+
 INSERT INTO table_a VALUES
   (1, 2, 3),
-  ('hello', 3, 4),
-  (3, 4, 5);
+  ('hello', 2, 3),
+  (1, 2, 3);
 
 INSERT INTO table_b VALUES
   (1, 2, 3),
-  (2, 'hello', 4),
-  (3, 4, 5);
+  (1, 'hello', 3),
+  (1, 2, 3);
 
 INSERT INTO table_c VALUES
   (1, 2, 3),
-  (2, 3, 'hello'),
-  (3, 4, 5);
+  (1, 2, 'hello'),
+  (1, 2, 3);
+
+INSERT INTO table_d VALUES
+  (1, 2, 3, 4),
+  (1, 'hello', 3, 'world'),
+  (1, 2, 3, 4),
+  (1, 'hello', 3, 'world');

--- a/test_schemas/typeless_columns.sql
+++ b/test_schemas/typeless_columns.sql
@@ -1,0 +1,32 @@
+CREATE TABLE table_a (
+    foo,
+    bar INTEGER,
+    boo INTEGER
+);
+
+CREATE TABLE table_b (
+    foo INTEGER,
+    bar,
+    boo INTEGER
+);
+
+CREATE TABLE table_c (
+    foo INTEGER,
+    bar INTEGER,
+    boo
+);
+
+INSERT INTO table_a VALUES
+  (1, 2, 3),
+  ('hello', 3, 4),
+  (3, 4, 5);
+
+INSERT INTO table_b VALUES
+  (1, 2, 3),
+  (2, 'hello', 4),
+  (3, 4, 5);
+
+INSERT INTO table_c VALUES
+  (1, 2, 3),
+  (2, 3, 'hello'),
+  (3, 4, 5);


### PR DESCRIPTION
Summary:
SQLite allows columns without types. However, `sqlglot` parses typeless columns as bare identifiers, which breaks an import when we try to reconcile with the columns known to `sqlite_utils`.

This PR wraps bare identifiers found at the table-schema level (same level as column definitions) in column definitions with a default `TEXT` type. 

Testing:

Correctly imports database with schema defined in [typeless_columns.sql](https://github.com/bitdotioinc/pgsqlite/compare/doss/update-identifier-handling...doss/handle-typeless-columns?expand=1#diff-e3edf81d8a5f23de78031fd28a3113b28e10c9c61cacefac00ed65a9c8273b1f)[typeless_columns.sql](https://github.com/bitdotioinc/pgsqlite/compare/doss/update-identifier-handling...doss/handle-typeless-columns?expand=1#diff-e3edf81d8a5f23de78031fd28a3113b28e10c9c61cacefac00ed65a9c8273b1f).
