### PR TITLE
Bump sqlglot dependency w/ recent fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "pgsqlite"
-VERSION = "1.0.1"
+VERSION = "1.0.2"
 # To install the library, run the following
 #
 # python setup.py install

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ VERSION = "1.0.1"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["sqlite-utils >= 3.28", "psycopg >= 3.1", "psycopg-binary >= 3.1", "structlog >= 22.1.0", "sqlglot >= 6.1.0"]
+REQUIRES = ["sqlite-utils >= 3.28", "psycopg >= 3.1", "psycopg-binary >= 3.1", "structlog >= 22.1.0", "sqlglot >= 10.5.7"]
 
 
 with open("README.md", "r", encoding="utf-8") as fh:


### PR DESCRIPTION
Bumping `sqlglot` dependency b/c `sqlglot` has made a number of recent improvements that benefit `sqlite` schema parsing.