### PR TITLE
Bump pgsqlite and sqlglot version for parsing fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "pgsqlite"
-VERSION = "1.0.2"
+VERSION = "1.0.3"
 # To install the library, run the following
 #
 # python setup.py install
@@ -18,7 +18,7 @@ VERSION = "1.0.2"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["sqlite-utils >= 3.28", "psycopg >= 3.1", "psycopg-binary >= 3.1", "structlog >= 22.1.0", "sqlglot >= 10.5.7"]
+REQUIRES = ["sqlite-utils >= 3.28", "psycopg >= 3.1", "psycopg-binary >= 3.1", "structlog >= 22.1.0", "sqlglot >= 10.6.3"]
 
 
 with open("README.md", "r", encoding="utf-8") as fh:


### PR DESCRIPTION
Bump to rerelease with latest sqlglot parser improvements that fix recent pgsqlite user issues:
- [Foreign key column constraints w/ `ON` clauses](https://github.com/tobymao/sqlglot/issues/1106).
- [`LONGVARCHAR` data type support](https://github.com/tobymao/sqlglot/pull/1107)(maps to Postgres `TEXT`).