### PR TITLE
configure asyncio correctly for win32 usage.

### DIFF
--- a/pgsqlite/pgsqlite.py
+++ b/pgsqlite/pgsqlite.py
@@ -181,6 +181,8 @@ class PGSqlite(object):
         self.max_import_concurrency = max_import_concurrency
         db = Database(self.sqlite_filename)
         self._tables = {t.name: ParsedTable(t) for t in db.tables}
+        if sys.platform == "win32":
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
     @property
     def tables(self):


### PR DESCRIPTION
This PR is to add needed asyncio config on the windows platform.

Script ran perfectly on my mac, when i tried to run it on my windows I received the following error:

`psycopg.InterfaceError: Psycopg cannot use the 'ProactorEventLoop' to run in async mode. Please use a compatible event loop, for instance by setting 'asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())'     `

Here is the fix to run on windows.